### PR TITLE
Removed parking lot 11

### DIFF
--- a/parkinglots.json
+++ b/parkinglots.json
@@ -7,13 +7,6 @@
     "user": "-nobody-"
   },
   {
-    "name": "Platz 11 - Fahrräder",
-    "state": {
-      "name": "FREE"
-    },
-    "user": "Patrick Heinen"
-  },
-  {
     "name": "Platz 25 (SF) - max H=1.50m",
     "state": {
       "name": "FREE"


### PR DESCRIPTION
Hi @DanielFroehlich,

we would like to remove parking lot 11 from the list of available parking lots. The reason behind this is that it may confuse people who do not often travel to Düsseldorf by car and do not know about the dedicated bicycle parking lot.

Please ping me / Jos if you need additional information.

Kind regards,
Christian

