### PR TITLE
Decreased livenessProbe sensitivity

### DIFF
--- a/openshift_template.yml
+++ b/openshift_template.yml
@@ -40,8 +40,8 @@ objects:
               scheme: HTTP
             initialDelaySeconds: 5
             periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
+            successThreshold: 3
+            timeoutSeconds: 5
           name: dusgarage
           ports:
           - containerPort: 8080


### PR DESCRIPTION
Hi Daniel,

We experience quite a few Pod restarts due to failing livenessProbes:

```
$ oc get pods
NAME                 READY   STATUS    RESTARTS   AGE
dusgarage-79-trgn4   1/1     Running   181        5d
```

```
$ oc get events --sort-by='{.metadata.creationTimestamp}'
LAST SEEN   FIRST SEEN   COUNT   NAME                                  KIND   SUBOBJECT                    TYPE      REASON      SOURCE                                  MESSAGE
35m         5d           182     dusgarage-79-trgn4.163191f7a1b3dac5   Pod    spec.containers{dusgarage}   Normal    Pulling     kubelet, ip-172-31-50-82.ec2.internal   pulling image "docker-registry.default.svc:5000/dusgarage-dev/dusgarage@sha256:da17a41b8c3aeaff07916890eea573c53d031ed00b78db54c800b02fa66ac604"
35m         5d           182     dusgarage-79-trgn4.163191fa9a2eff9a   Pod    spec.containers{dusgarage}   Normal    Pulled      kubelet, ip-172-31-50-82.ec2.internal   Successfully pulled image "docker-registry.default.svc:5000/dusgarage-dev/dusgarage@sha256:da17a41b8c3aeaff07916890eea573c53d031ed00b78db54c800b02fa66ac604"
35m         5d           182     dusgarage-79-trgn4.163191fc151f3484   Pod    spec.containers{dusgarage}   Normal    Created     kubelet, ip-172-31-50-82.ec2.internal   Created container
35m         5d           182     dusgarage-79-trgn4.163191fc21cf170e   Pod    spec.containers{dusgarage}   Normal    Started     kubelet, ip-172-31-50-82.ec2.internal   Started container
35m         5d           76      dusgarage-79-trgn4.163192184c15885a   Pod    spec.containers{dusgarage}   Warning   Unhealthy   kubelet, ip-172-31-50-82.ec2.internal   Liveness probe failed: Get http://10.129.17.81:8080/health: dial tcp 10.129.17.81:8080: connect: connection refused
```

As a first step, I would like to suggest to decrease the probes aggressiveness. CC @joschro
