### PR TITLE
Fix dusgarage door dynamic DNS

### DIFF
--- a/demo_template.yml
+++ b/demo_template.yml
@@ -171,9 +171,9 @@ objects:
       config.GOOGLE_CLIENT_SECRET = "i6rYSDSv4i30JhC6E7MGoF1k"
       config.GOOGLE_CALLBACK_URL = "http://dusgarage-dusgarage-demo.6923.rh-us-east-1.openshiftapps.com/oauth2callback"
 
-      config.DOOR_URL_CHECK = "http://redhat:R3dHat123@dus-garage.privatedns.org:8000/dus/garagetest/value"
+      config.DOOR_URL_CHECK = "http://redhat:R3dHat123@rhdus.freedns.io:8000/dus/garagetest/value"
       config.DOOR_TIMEOUT = 15000
-      config.DOOR_URL_OPEN = "http://redhat:R3dHat123@dus-garage.privatedns.org:8000/dus/garagetest/value/1"
+      config.DOOR_URL_OPEN = "http://redhat:R3dHat123@rhdus.freedns.io:8000/dus/garagetest/value/1"
 
       // ------------------------
       // CRON Entries. Syntax:

--- a/openshift_template.yml
+++ b/openshift_template.yml
@@ -106,9 +106,9 @@ objects:
       config.GOOGLE_CLIENT_SECRET = "i6rYSDSv4i30JhC6E7MGoF1k"
       config.GOOGLE_CALLBACK_URL = "http://dusgarage-dusgarage-dev.6923.rh-us-east-1.openshiftapps.com/oauth2callback"
 
-      config.DOOR_URL_CHECK = "http://redhat:R3dHat123@dus-garage.privatedns.org:8000/dus/garagetest/value"
+      config.DOOR_URL_CHECK = "http://redhat:R3dHat123@rhdus.freedns.io:8000/dus/garagetest/value"
       config.DOOR_TIMEOUT = 15000
-      config.DOOR_URL_OPEN = "http://redhat:R3dHat123@dus-garage.privatedns.org:8000/dus/garagetest/value/1"
+      config.DOOR_URL_OPEN = "http://redhat:R3dHat123@rhdus.freedns.io:8000/dus/garagetest/value/1"
 
       // ------------------------
       // CRON Entries. Syntax:


### PR DESCRIPTION
It appears as if privatedns.org was deprecated.

```
$ curl -I http://redhat:R3dHat123@dus-garage.privatedns.org:8000/dus/garagetest/value
curl: (6) Could not resolve host: dus-garage.privatedns.org

$ curl -I -X GET http://redhat:R3dHat123@rhdus.freedns.io:8000/dus/garagetest/value
HTTP/1.0 200 OK
Server: WebIOPi/0.7.1/Python2.7
Date: Fri, 11 Dec 2020 16:52:05 GMT
Cache-Control: no-cache
Content-Type: text/plain
Content-Length: 1
```